### PR TITLE
Changed to store param values in shared preferences

### DIFF
--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -3,6 +3,7 @@ package com.rnappauth;
 import android.app.Activity;
 import android.app.PendingIntent;
 import android.content.ComponentName;
+import android.content.SharedPreferences;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
@@ -62,17 +63,12 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
 
     private final ReactApplicationContext reactContext;
     private Promise promise;
-    private boolean dangerouslyAllowInsecureHttpRequests;
-    private Boolean skipCodeExchange;
-    private Boolean usePKCE;
     private Boolean useNonce;
-    private String codeVerifier;
     private String clientAuthMethod = "basic";
     private Map<String, String> registrationRequestHeaders = null;
     private Map<String, String> authorizationRequestHeaders = null;
     private Map<String, String> tokenRequestHeaders = null;
     private Map<String, String> additionalParametersMap;
-    private String clientSecret;
     private final ConcurrentHashMap<String, AuthorizationServiceConfiguration> mServiceConfigurations = new ConcurrentHashMap<>();
     private boolean isPrefetched = false;
 
@@ -236,13 +232,17 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
 
         // store args in private fields for later use in onActivityResult handler
         this.promise = promise;
-        this.dangerouslyAllowInsecureHttpRequests = dangerouslyAllowInsecureHttpRequests;
         this.additionalParametersMap = additionalParametersMap;
-        this.clientSecret = clientSecret;
         this.clientAuthMethod = clientAuthMethod;
-        this.skipCodeExchange = skipCodeExchange;
         this.useNonce = useNonce;
-        this.usePKCE = usePKCE;
+
+        SharedPreferences sharedPref = getCurrentActivity().getPreferences(Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = sharedPref.edit();
+        editor.putBoolean("dangerouslyAllowInsecureHttpRequests", dangerouslyAllowInsecureHttpRequests);
+        editor.putBoolean("skipCodeExchange", skipCodeExchange);
+        editor.putBoolean("usePKCE", usePKCE);
+        editor.putString("clientSecret", clientSecret);
+        editor.apply();
 
         // when serviceConfiguration is provided, we don't need to hit up the OpenID well-known id endpoint
         if (serviceConfiguration != null || hasServiceConfiguration(issuer)) {
@@ -330,7 +330,10 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
         }
 
         // store setting in private field for later use in onActivityResult handler
-        this.dangerouslyAllowInsecureHttpRequests = dangerouslyAllowInsecureHttpRequests;
+        SharedPreferences sharedPref = getCurrentActivity().getPreferences(Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = sharedPref.edit();
+        editor.putBoolean("dangerouslyAllowInsecureHttpRequests", dangerouslyAllowInsecureHttpRequests);
+        editor.apply();
         this.additionalParametersMap = additionalParametersMap;
 
         // when serviceConfiguration is provided, we don't need to hit up the OpenID well-known id endpoint
@@ -416,10 +419,17 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                 return;
             }
 
-            if (this.skipCodeExchange) {
+            SharedPreferences sharedPref = getCurrentActivity().getPreferences(Context.MODE_PRIVATE);
+            Boolean skipCodeExchange = sharedPref.getBoolean("skipCodeExchange", false);
+
+            if (skipCodeExchange) {
+       
+                String codeVerifier = sharedPref.getString("codeVerifier", null);
+                Boolean usePKCE = sharedPref.getBoolean("usePKCE", true);
+
                 WritableMap map;
-                if (this.usePKCE && this.codeVerifier != null) {
-                    map = TokenResponseFactory.authorizationCodeResponseToMap(response, this.codeVerifier);
+                if (usePKCE && codeVerifier != null) {
+                    map = TokenResponseFactory.authorizationCodeResponseToMap(response, codeVerifier);
                 } else {
                     map = TokenResponseFactory.authorizationResponseToMap(response);
                 }
@@ -430,16 +440,16 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                 return;
             }
 
-
+            Boolean dangerouslyAllowInsecureHttpRequests = sharedPref.getBoolean("dangerouslyAllowInsecureHttpRequests", false);
             final Promise authorizePromise = this.promise;
             final AppAuthConfiguration configuration = createAppAuthConfiguration(
-                    createConnectionBuilder(this.dangerouslyAllowInsecureHttpRequests, this.tokenRequestHeaders),
-                    this.dangerouslyAllowInsecureHttpRequests
+                    createConnectionBuilder(dangerouslyAllowInsecureHttpRequests, this.tokenRequestHeaders),
+                    dangerouslyAllowInsecureHttpRequests
             );
 
             AuthorizationService authService = new AuthorizationService(this.reactContext, configuration);
 
-            TokenRequest tokenRequest = response.createTokenExchangeRequest(this.additionalParametersMap);
+            TokenRequest tokenRequest = this.additionalParametersMap? response.createTokenExchangeRequest(this.additionalParametersMap) : response.createTokenExchangeRequest();
 
             AuthorizationService.TokenResponseCallback tokenResponseCallback = new AuthorizationService.TokenResponseCallback() {
 
@@ -459,13 +469,23 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                 }
             };
 
-            if (this.clientSecret != null) {
-                ClientAuthentication clientAuth = this.getClientAuthentication(this.clientSecret, this.clientAuthMethod);
+            String clientSecret = sharedPref.getString("clientSecret", null);   
+            if (clientSecret != null) {
+                ClientAuthentication clientAuth = this.getClientAuthentication(clientSecret, this.clientAuthMethod);
                 authService.performTokenRequest(tokenRequest, clientAuth, tokenResponseCallback);
 
             } else {
                 authService.performTokenRequest(tokenRequest, tokenResponseCallback);
             }
+
+            SharedPreferences.Editor editor = sharedPref.edit();
+            editor.remove("dangerouslyAllowInsecureHttpRequests")
+            editor.remove("clientSecret")
+            editor.remove("dangerouslyAllowInsecureHttpRequests")
+            editor.remove("skipCodeExchange")
+            editor.remove("usePKCE")
+            editor.remove("codeVerifier")
+            editor.apply();
 
         }
     }
@@ -588,8 +608,12 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
         if (!usePKCE) {
             authRequestBuilder.setCodeVerifier(null);
         } else {
-            this.codeVerifier = CodeVerifierUtil.generateRandomCodeVerifier();
-            authRequestBuilder.setCodeVerifier(this.codeVerifier);
+            String codeVerifier = CodeVerifierUtil.generateRandomCodeVerifier();
+            SharedPreferences sharedPref = getCurrentActivity().getPreferences(Context.MODE_PRIVATE);
+            SharedPreferences.Editor editor = sharedPref.edit();
+            editor.putString("codeVerifier", codeVerifier);
+            editor.apply();
+            authRequestBuilder.setCodeVerifier(codeVerifier);
         }
 
         if(!useNonce) {
@@ -675,6 +699,10 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
         } else {
             authService.performTokenRequest(tokenRequest, tokenResponseCallback);
         }
+            SharedPreferences sharedPref = getCurrentActivity().getPreferences(Context.MODE_PRIVATE);
+            SharedPreferences.Editor editor = sharedPref.edit();
+            editor.remove("dangerouslyAllowInsecureHttpRequests")
+            editor.apply()
     }
 
     private void parseHeaderMap (ReadableMap headerMap) {


### PR DESCRIPTION
Fixes [#672](https://github.com/FormidableLabs/react-native-app-auth/issues/672), [#360](https://github.com/FormidableLabs/react-native-app-auth/issues/360)

## Description

Fixes app crash issue on authorize for Android

## Steps to verify

Enable "Don't Keep Activities" setting in your android Device's Developer Setting,
Authenticate user using authorize method

<!-- Please ensure you have have updated the tests, readme, typescript definitions -->
